### PR TITLE
README: Elm version and install instructions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ To start the app:
 
   * Install dependencies with `mix deps.get`
   * Install Node.js dependencies with `npm install`
+  * Install Elm v0.17.1 with `npm install -g elm@0.17.1` or follow instructions [here](https://guide.elm-lang.org/install.html) (just remember to use v0.17.1)
   * With Redis installed, start it with `redis-server`
   * Start Phoenix endpoint with `mix phoenix.server`
 


### PR DESCRIPTION
Title says it all. If Elm is not installed, `brunch` is unable to compile elm sources. Default Elm install instructions are for 0.18 that is not compatible with elm code used in this app.

Let me what you think.